### PR TITLE
extend next-auth user to match prisma schema

### DIFF
--- a/nextauth.d.ts
+++ b/nextauth.d.ts
@@ -1,0 +1,8 @@
+import NextAuth, { DefaultSession } from "next-auth";
+import { User as UserModel } from "@prisma/client";
+
+declare module "next-auth" {
+  interface User extends UserModel {
+    id: number; // <- we need to set this as number to match our prisma schema
+  }
+}


### PR DESCRIPTION
In our prisma schema the user id is a number, thus we need to extend next-auth's user to match that. 
This fixes a type error on `app/api/auth/[...nextauth]/route.ts`