### PR TITLE
add NEXTAUTH_URL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ POSTGRES_DATABASE=
 
 # Generate one here: https://generate-secret.vercel.app/32 (only required for localhost)
 NEXTAUTH_SECRET=
+NEXTAUTH_URL=


### PR DESCRIPTION
For authentication to work locally on development, in addition to `NEXTAUTH_SECRET`, we need to set `NEXTAUTH_URL` environment variable. This avoids a `TypeError [ERR_INVALID_URL]: Invalid URL` when trying to login locally.