### PR TITLE
Fix TypeScript typing error

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -24,7 +24,10 @@ export const authOptions: NextAuthOptions = {
         if (!user || !(await compare(password, user.password))) {
           throw new Error("Invalid username or password");
         }
-        return user;
+        return {
+          ...user,
+          id: user.id.toString(),
+        };
       },
     }),
   ],


### PR DESCRIPTION
This was giving me an error in my IDE. I'm not sure if this is the correct solution though, but it silences the error. The error may lie with the CredentialsProvider class and simply fixing the typing to allow a number instead of a string, but that is an upstream dependency.