### PR TITLE
no need to specify jsonProtocol since prisma 5.0.0

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["jsonProtocol"]
 }
 
 datasource db {


### PR DESCRIPTION
Prisma schema warning:
- Preview feature "jsonProtocol" is deprecated. The functionality can be used without specifying it as a preview feature

https://github.com/prisma/prisma/releases/tag/5.0.0