### PR TITLE
Update .env.example with HS512 secret and added NEXTAUTH_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,6 @@ POSTGRES_HOST=
 POSTGRES_PASSWORD=
 POSTGRES_DATABASE=
 
-# Generate one here: https://generate-secret.vercel.app/32 (only required for localhost)
+# Generate a HS512 compatible secret (only required for localhost)
 NEXTAUTH_SECRET=
+NEXTAUTH_URL=


### PR DESCRIPTION
Updates .env.example:

1. Updates comment about secret generation to require a HS512 secret fixing issue https://github.com/vercel/nextjs-postgres-auth-starter/issues/39. 

New comment: "#Generate a HS512 compatible secret (only required for localhost)"

2. Adds NEXTAUTH_URL avoiding "TypeError [ERR_INVALID_URL]: Invalid URL" error as already covered in PR https://github.com/vercel/nextjs-postgres-auth-starter/pull/31.

First pull request, let me know if I did something wrong.