### PR TITLE
Update prisma.ts to remove type error.

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,11 +1,17 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
-declare global {
-  var prisma: PrismaClient | undefined;
+let prisma: PrismaClient;
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient();
+} else {
+  let globalWithPrisma = global as typeof globalThis & {
+    prisma: PrismaClient;
+  };
+  if (!globalWithPrisma.prisma) {
+    globalWithPrisma.prisma = new PrismaClient();
+  }
+  prisma = globalWithPrisma.prisma;
 }
-
-const prisma = global.prisma || new PrismaClient();
-
-if (process.env.NODE_ENV === "development") global.prisma = prisma;
 
 export default prisma;


### PR DESCRIPTION
Updated prisma client to remove error with this suggested fix:
https://github.com/prisma/prisma/discussions/10037#discussioncomment-1572155

Removes the error:
`Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.`