### PR TITLE
fix: do not use explicit shadow database

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,6 @@ datasource db {
   provider = "postgresql"
   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 model User {


### PR DESCRIPTION
Removes the shadow database URL to fix the bugs once migrations are introduced.

See [shadow database documentation](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database) and https://github.com/prisma/prisma/issues/19234#issuecomment-1693746150. 

> Important: Do not use the same values for directUrl and shadowDatabaseUrl.